### PR TITLE
Add #include <algorithm> to support std::min

### DIFF
--- a/include/b64/encode.h
+++ b/include/b64/encode.h
@@ -8,6 +8,7 @@ For details, see http://sourceforge.net/projects/libb64
 #ifndef BASE64_ENCODE_H
 #define BASE64_ENCODE_H
 
+#include <algorithm>
 #include <iostream>
 
 namespace base64


### PR DESCRIPTION
std::min is defined in the \<algorithm\> header. It's not advised to rely on \<iostream\> to include it for you.
The repository as it is gives a compilation error on Windows: "libb64/include/b64/encode.h(89): error C3861: 'min': identifier not found".